### PR TITLE
change the return value type from string to array for laravel 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "php": ">=7.4",
     "ext-json": "*",
     "ext-pdo": "*",
-    "laravel/framework": "~6.0|~7.0|~8.0"
+    "laravel/framework": "~8.0"
   },
   "require-dev": {
     "orchestra/testbench": "~3.5|~4.0|~5.0",

--- a/src/Colopl/TiDB/Schema/Grammar.php
+++ b/src/Colopl/TiDB/Schema/Grammar.php
@@ -55,12 +55,9 @@ class Grammar extends MySqlGrammar
      */
     public function compileCreate(BaseBluePrint $blueprint, Fluent $command, Connection $connection)
     {
-        $arr = parent::compileCreate($blueprint, $command, $connection);
-        $sql = $arr[0];
-        $sql = $this->compileCreateShards($sql, $connection, $blueprint);
-        $arr[0] = $sql;
-
-        return $arr;
+        $res = parent::compileCreate($blueprint, $command, $connection);
+        $res[0] = $this->compileCreateShards($res[0], $connection, $blueprint);
+        return $res;
     }
 
     /**

--- a/src/Colopl/TiDB/Schema/Grammar.php
+++ b/src/Colopl/TiDB/Schema/Grammar.php
@@ -51,15 +51,16 @@ class Grammar extends MySqlGrammar
      * @param  BaseBlueprint  $blueprint
      * @param  Fluent  $command
      * @param  Connection  $connection
-     * @return string
+     * @return array
      */
     public function compileCreate(BaseBluePrint $blueprint, Fluent $command, Connection $connection)
     {
-        $sql = parent::compileCreate($blueprint, $command, $connection);
-
+        $arr = parent::compileCreate($blueprint, $command, $connection);
+        $sql = $arr[0];
         $sql = $this->compileCreateShards($sql, $connection, $blueprint);
+        $arr[0] = $sql;
 
-        return $sql;
+        return $arr;
     }
 
     /**
@@ -91,11 +92,11 @@ class Grammar extends MySqlGrammar
      */
     protected function compileCreateTable($blueprint, $command, $connection)
     {
-        return sprintf('%s table %s (%s)',
+        return trim(sprintf('%s table %s (%s)',
             $blueprint->temporary ? 'create temporary' : 'create',
             $this->wrapTable($blueprint),
             implode(', ', array_merge($this->getColumns($blueprint), $this->getIndexes($blueprint))),
-        );
+        ));
     }
 
     /**


### PR DESCRIPTION
Hi, since laravel 8.0 mysql ORM has an incompatible change, so a new colopl/laravel-tidb version may be needed for 8.0+ support.

I have tried to give a fix, please review it.

ref:
https://github.com/laravel/framework/commit/7d158b4feb17fd1571f26bc130b140b278e4e289#diff-56c5c7428a9c212202ed1ff8087231537cb51af4e53de282d6c7b0675ba57e46L52-L76
