### PR TITLE
Add support for Grammar's escape function

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -31,7 +31,9 @@ class Connection extends MySqlConnection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        ($grammar = new QueryGrammar)->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**
@@ -39,7 +41,9 @@ class Connection extends MySqlConnection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        ($grammar = new SchemaGrammar)->setConnection($this);
+
+        return $this->withTablePrefix($grammar);
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -23,6 +23,7 @@ use Colopl\TiDB\Schema\Builder as SchemaBuilder;
 use Colopl\TiDB\Schema\Grammar as SchemaGrammar;
 use Illuminate\Database\Grammar;
 use Illuminate\Database\MySqlConnection;
+use function method_exists;
 
 class Connection extends MySqlConnection
 {
@@ -31,7 +32,10 @@ class Connection extends MySqlConnection
      */
     protected function getDefaultQueryGrammar()
     {
-        ($grammar = new QueryGrammar)->setConnection($this);
+        $grammar = new QueryGrammar;
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($this);
+        }
 
         return $this->withTablePrefix($grammar);
     }
@@ -41,7 +45,10 @@ class Connection extends MySqlConnection
      */
     protected function getDefaultSchemaGrammar()
     {
-        ($grammar = new SchemaGrammar)->setConnection($this);
+        $grammar = new SchemaGrammar;
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($this);
+        }
 
         return $this->withTablePrefix($grammar);
     }


### PR DESCRIPTION
Since version 10.13, Laravel has introduced the `Illuminate\Database\Grammar::escape` function to retrieve raw SQL strings. （[#46558](https://github.com/laravel/framework/pull/46558), [#47507](https://github.com/laravel/framework/pull/47507)）
With this change, the Grammar class now requires a connection instance, and this update ensures that requirement is met.