### PR TITLE
fix: incorrect modifiers

### DIFF
--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -24,15 +24,10 @@ use Illuminate\Support\Fluent;
 
 class Grammar extends MySqlGrammar
 {
-    /**
-     * @var array
-     */
-    protected $modifiers = [
-        'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable',
-        'Srid', 'Default', 'Increment', 'Comment', 'After', 'First',
-        // TiDB Specific Modifiers
-        'AutoRandom',
-    ];
+    public function __construct()
+    {
+        $this->modifiers[] = 'AutoRandom';
+    }
 
     /**
      * @param  BaseBlueprint  $blueprint


### PR DESCRIPTION
The modifiers have changed in parent class but it's not reflected because it's overridden.

The child class was overriding to add TiDB specific modifiers.

Changed the code so that it doesn't override the parent property and add the TiDB specific modifier on class initialization instead.

For reference, parent modifier for v11 looks like below.

```
protected $modifiers = [
        'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable',
        'Default', 'OnUpdate', 'Invisible', 'Increment', 'Comment', 'After', 'First',
    ];
```